### PR TITLE
Add Open in DuckDuckGo support

### DIFF
--- a/LegacyDatabase/TGShareContextSignal.m
+++ b/LegacyDatabase/TGShareContextSignal.m
@@ -7,7 +7,7 @@
 #import <CommonCrypto/CommonKeyDerivation.h>
 #import <CommonCrypto/CommonCryptoError.h>
 
-#import "../../config.h"
+#import "../config.h"
 
 #import "TGLocalization.h"
 

--- a/LegacyDatabase/TGShareContextSignal.m
+++ b/LegacyDatabase/TGShareContextSignal.m
@@ -7,7 +7,7 @@
 #import <CommonCrypto/CommonKeyDerivation.h>
 #import <CommonCrypto/CommonCryptoError.h>
 
-#import "../config.h"
+#import "../../config.h"
 
 #import "TGLocalization.h"
 

--- a/Telegraph/TGOpenInBrowserItems.m
+++ b/Telegraph/TGOpenInBrowserItems.m
@@ -283,13 +283,13 @@
     if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"])
         return;
     
-    NSURL *openInURL = [NSURL URLWithString:[NSString stringWithFormat:@"ddgQuickLink://%@", url.absoluteString]];
+    NSURL *openInURL = [NSURL URLWithString:[NSString stringWithFormat:@"ddgquicklink://%@", url.absoluteString]];
     [TGOpenInBrowserItem openURL:openInURL];
 }
 
 + (NSString *)defaultURLScheme
 {
-    return @"ddgQuickLink";
+    return @"ddgquicklink";
 }
 
 @end

--- a/Telegraph/TGOpenInBrowserItems.m
+++ b/Telegraph/TGOpenInBrowserItems.m
@@ -22,6 +22,9 @@
 
 @end
 
+@interface TGOpenInDuckDuckGoItem : TGOpenInBrowserItem
+
+@end
 
 @interface TGOpenInBrowserItem ()
 
@@ -41,7 +44,8 @@
             [TGOpenInChromeItem class],
             [TGOpenInFirefoxItem class],
             [TGOpenInOperaItem class],
-            [TGOpenInYandexItem class]
+            [TGOpenInYandexItem class],
+            [TGOpenInDuckDuckGoItem class]
         ];
     });
     return appItems;
@@ -255,6 +259,37 @@
 + (NSString *)defaultURLScheme
 {
     return @"yandexbrowser-open-url";
+}
+
+@end
+
+@implementation TGOpenInDuckDuckGoItem
+
+- (NSString *)title
+{
+    return @"DuckDuckGo";
+}
+
+- (NSInteger)storeIdentifier
+{
+    return 663592361;
+}
+
+- (void)performOpenIn
+{
+    NSURL *url = (NSURL *)self.object;
+    NSString *scheme = [url.scheme lowercaseString];
+    
+    if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"])
+        return;
+    
+    NSURL *openInURL = [NSURL URLWithString:[NSString stringWithFormat:@"ddgQuickLink://%@", url.absoluteString]];
+    [TGOpenInBrowserItem openURL:openInURL];
+}
+
++ (NSString *)defaultURLScheme
+{
+    return @"ddgQuickLink";
 }
 
 @end

--- a/Telegraph/Telegraph-Info.plist
+++ b/Telegraph/Telegraph-Info.plist
@@ -112,7 +112,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>67581</string>
+	<string>67587</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption </key>
@@ -121,6 +121,7 @@
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>ddgquicklink</string>
 		<string>dbapi-3</string>
 		<string>instagram</string>
 		<string>googledrive</string>

--- a/Telegraph/Telegraph-Info.plist
+++ b/Telegraph/Telegraph-Info.plist
@@ -112,7 +112,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>67587</string>
+	<string>67581</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption </key>


### PR DESCRIPTION
Fixes #279 by adding DuckDuckGo to the list of supported browsers when the user taps a link and is shown the "Open In..." sheet.

**Tests**

1. Without DuckDuckGo installed, tap on a link in Telegram.

The Open In... sheet shows and lets the user choose from existing supported browsers.  DuckDuckGo is not present.

2. Install DuckDuckGo, tap on a link in Telegram

The Open In... sheet now shows DuckDuckGo as an option.

3. Select DuckDuckGo from the Open In... dialog

The URL will open in the DuckDuckGo app

