### PR TITLE
Add support for Smart Invert on legacy image views

### DIFF
--- a/submodules/LegacyComponents/LegacyComponents/TGImageView.m
+++ b/submodules/LegacyComponents/LegacyComponents/TGImageView.m
@@ -28,6 +28,10 @@ NSString *TGImageViewOptionSynchronous = @"TGImageViewOptionSynchronous";
     self = [super initWithFrame:frame];
     if (self != nil)
     {
+        if (iosMajorVersion() >= 11) {
+            self.accessibilityIgnoresInvertColors = true;
+        }
+        
         _disposable = [[SMetaDisposable alloc] init];
         _legacyAutomaticProgress = true;
     }


### PR DESCRIPTION
There are a few places throughout the app (TGSharedMediaController, TGStickersMenu, TGModenConcersationReplyAssociatedPanel [sic], TGModernFlatteningView) that still use the legacy TGImageView class, which does not currently support Smart Invert. This patch enables Smart Invert support for everything that uses TGImageView.